### PR TITLE
Fixed TypeError if device type is not available

### DIFF
--- a/src/components/Zigbee2mqttNetworkmap.vue
+++ b/src/components/Zigbee2mqttNetworkmap.vue
@@ -180,7 +180,7 @@ export default {
         return {
           id: d.ieeeAddr,
           name: d.type === 'Coordinator' ? ' ' : d.friendlyName,
-          _cssClass: d.type.toLowerCase()
+          _cssClass: d.type ? d.type.toLowerCase() : ''
         }
       })
       const nodes = attr.nodes.map(e => e.ieeeAddr)


### PR DESCRIPTION
If the device scan returns an entity without its type, the script will fail to render due to a TypeError.

For example, this is a valid entry
`{
      "ieeeAddr": "0xccccccfffead8b3e",
      "friendlyName": "0xccccccfffead8b3e",
      "networkAddress": 44418,
      "failed": [
        "lqi"
      ],
      "lastSeen": 1575244092941
}`