### PR TITLE
Update for new zigbee2mqtt API added in 1.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Home Assistant setup
 
-Update Zigbee2mqtt to version 1.5.1 or later, earlier version may not work.
+Update Zigbee2mqtt to version 1.17.0 or later, earlier version may not work.
 
 This instruction is for Home Assistant 0.107 and later.
 
@@ -22,12 +22,12 @@ sensor:
   - platform: mqtt
     name: Zigbee2mqtt Networkmap
     # if you change base_topic of Zigbee2mqtt, change state_topic accordingly
-    state_topic: zigbee2mqtt/bridge/networkmap/raw
+    state_topic: zigbee2mqtt/bridge/response/networkmap
     value_template: >-
       {{ now().strftime('%Y-%m-%d %H:%M:%S') }}
     # again, if you change base_topic of Zigbee2mqtt, change json_attributes_topic accordingly
-    json_attributes_topic: zigbee2mqtt/bridge/networkmap/raw
-
+    json_attributes_topic: zigbee2mqtt/bridge/response/networkmap
+    json_attributes_template: "{{ value_json.data.value | tojson }}"
 ```
 
 ### Frontend setup (manual)

--- a/src/components/Zigbee2mqttNetworkmap.vue
+++ b/src/components/Zigbee2mqttNetworkmap.vue
@@ -165,8 +165,8 @@ export default {
       this.state = 'Refreshing...'
       const mqttBaseTopic = this.config.mqtt_base_topic || 'zigbee2mqtt'
       this.hass.callService('mqtt', 'publish', {
-        topic: mqttBaseTopic + '/bridge/networkmap',
-        payload: 'raw'
+        topic: mqttBaseTopic + '/bridge/request/networkmap',
+        payload: JSON.stringify({type: 'raw', routes: true})
       })
     },
     update () {


### PR DESCRIPTION
Zigbee2mqtt introduced a [new API](https://www.zigbee2mqtt.io/information/mqtt_topics_and_message_structure.html#mqtt-topics-and-message-structure) in v1.17.0 - this requires changes to the map sensor as well as the JavaScript code to send an updated payload on the new topic.

This change updates the README with instructions for setting up with zigbee2mqtt v1.17.0, as well as the code changes to ensure "Refresh" sends to the right topic.