### PR TITLE
Prevent undefined exception

### DIFF
--- a/src/components/Zigbee2mqttNetworkmap.vue
+++ b/src/components/Zigbee2mqttNetworkmap.vue
@@ -121,7 +121,7 @@ export default {
   watch: {
     hass (newHass, oldHass) {
       const entity = this.config.entity
-      if (newHass && entity) {
+      if (newHass && entity && newHass.states[entity]) {
         const newAttr = newHass.states[entity].attributes
         let oldAttr = null
         if (oldHass) {


### PR DESCRIPTION
Prevent an undefined exception when the network map has never been published yet.